### PR TITLE
chore: add .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php
+{
+    "name": "PHP",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/php:0-8.2",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8080
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/guiyomh/features/vim:0": {}
+    },
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+    "postCreateCommand": "npm install; composer update"
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}


### PR DESCRIPTION
This allows the use of [Dev Containers](https://containers.dev/) either in local ([VSCode guide](https://code.visualstudio.com/docs/devcontainers/containers)) or in the cloud with services like [GitHub Codespaces](https://github.com/features/codespaces).

Dev containers allow to streamline development by removing the need to configure your workspace, and reducing the possibility of dependency conflicts in your local environment: to me this is especially useful since we're working with PHP and Docker.

This has no impact on the ability to install everything locally as before.